### PR TITLE
Bug fix: Do not unmarshal and re-marshal scheduled job instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LDFLAGS=-s -w
 cli:
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/add-job cmd/add-job/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/get-job cmd/get-job/main.go
+	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/get-job cmd/schedule-job/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/remove-job cmd/remove-job/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/job-server cmd/job-server/main.go
 

--- a/app/job/add/add.go
+++ b/app/job/add/add.go
@@ -4,25 +4,30 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-offline"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	flagset.Parse(fs)
 
-	db, err := offline.NewDatabase(ctx, database_uri)
+	if verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
+
+	db, err := offline.NewDatabase(ctx, offline_database_uri)
 
 	if err != nil {
-		return fmt.Errorf("Failed to create offline database for '%s', %w", database_uri, err)
+		return fmt.Errorf("Failed to create offline database for '%s', %w", offline_database_uri, err)
 	}
 
 	job, err := offline.NewJob(ctx, creator, job_type, instructions)

--- a/app/job/add/flags.go
+++ b/app/job/add/flags.go
@@ -6,19 +6,21 @@ import (
 	"github.com/sfomuseum/go-flags/flagset"
 )
 
-var database_uri string
+var offline_database_uri string
 var creator string
 var job_type string
 var instructions string
+var verbose bool
 
 func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("offline")
 
-	fs.StringVar(&database_uri, "database-uri", "", "")
+	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "A registered sfomuseum/go-offline.Database URI.")
 	fs.StringVar(&creator, "creator", "", "")
 	fs.StringVar(&job_type, "type", "", "")
 	fs.StringVar(&instructions, "instructions", "", "")
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 
 	return fs
 }

--- a/app/job/get/flags.go
+++ b/app/job/get/flags.go
@@ -6,15 +6,17 @@ import (
 	"github.com/sfomuseum/go-flags/flagset"
 )
 
-var database_uri string
+var offline_database_uri string
 var job_id int64
+var verbose bool
 
 func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("offline")
 
-	fs.StringVar(&database_uri, "database-uri", "", "")
+	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "A registered sfomuseum/go-offline.Database URI.")
 	fs.Int64Var(&job_id, "job-id", 0, "")
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 
 	return fs
 }

--- a/app/job/get/get.go
+++ b/app/job/get/get.go
@@ -5,23 +5,28 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-offline"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	flagset.Parse(fs)
 
-	db, err := offline.NewDatabase(ctx, database_uri)
+	if verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
+
+	db, err := offline.NewDatabase(ctx, offline_database_uri)
 
 	if err != nil {
 		return fmt.Errorf("Failed to create offline database, %w", err)

--- a/app/job/remove/flags.go
+++ b/app/job/remove/flags.go
@@ -6,15 +6,17 @@ import (
 	"github.com/sfomuseum/go-flags/flagset"
 )
 
-var database_uri string
+var offline_database_uri string
 var job_id int64
+var verbose bool
 
 func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("offline")
 
-	fs.StringVar(&database_uri, "database-uri", "", "")
+	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "A registered sfomuseum/go-offline.Database URI.")
 	fs.Int64Var(&job_id, "job-id", 0, "")
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 
 	return fs
 }

--- a/app/job/remove/remove.go
+++ b/app/job/remove/remove.go
@@ -4,22 +4,27 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-offline"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	flagset.Parse(fs)
 
-	db, err := offline.NewDatabase(ctx, database_uri)
+	if verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
+
+	db, err := offline.NewDatabase(ctx, offline_database_uri)
 
 	if err != nil {
 		return fmt.Errorf("Failed to create offline database, %w", err)

--- a/app/job/schedule/flags.go
+++ b/app/job/schedule/flags.go
@@ -1,4 +1,4 @@
-package get
+package schedule
 
 import (
 	"flag"

--- a/app/job/schedule/flags.go
+++ b/app/job/schedule/flags.go
@@ -10,14 +10,16 @@ import (
 var offline_database_uri string
 var offline_queue_uris multi.KeyValueString
 var job_id int64
+var verbose bool
 
 func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("offline")
 
-	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "...")
-	fs.Var(&offline_queue_uris, "offline-queue-uri", "...")
-	fs.Int64Var(&job_id, "job-id", 0, "...")
+	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "A registered sfomuseum/go-offline.Database URI.")
+	fs.Var(&offline_queue_uris, "offline-queue-uri", "One or more {TASK}={QUEUE_URI} key-value pairs mapping a job type to a registered sfomuseum/go-offline.Queue URI.")
+	fs.Int64Var(&job_id, "job-id", 0, "The job ID to schedule.")
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 
 	return fs
 }

--- a/app/job/schedule/flags.go
+++ b/app/job/schedule/flags.go
@@ -4,19 +4,20 @@ import (
 	"flag"
 
 	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/sfomuseum/go-flags/multi"
 )
 
-var database_uri string
-var queue_uri string
+var offline_database_uri string
+var offline_queue_uris multi.KeyValueString
 var job_id int64
 
 func DefaultFlagSet() *flag.FlagSet {
 
 	fs := flagset.NewFlagSet("offline")
 
-	fs.StringVar(&database_uri, "database-uri", "", "")
-	fs.StringVar(&queue_uri, "queue-uri", "", "")
-	fs.Int64Var(&job_id, "job-id", 0, "")
+	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "...")
+	fs.Var(&offline_queue_uris, "offline-queue-uri", "...")
+	fs.Int64Var(&job_id, "job-id", 0, "...")
 
 	return fs
 }

--- a/app/job/schedule/flags.go
+++ b/app/job/schedule/flags.go
@@ -1,0 +1,22 @@
+package get
+
+import (
+	"flag"
+
+	"github.com/sfomuseum/go-flags/flagset"
+)
+
+var database_uri string
+var queue_uri string
+var job_id int64
+
+func DefaultFlagSet() *flag.FlagSet {
+
+	fs := flagset.NewFlagSet("offline")
+
+	fs.StringVar(&database_uri, "database-uri", "", "")
+	fs.StringVar(&queue_uri, "queue-uri", "", "")
+	fs.Int64Var(&job_id, "job-id", 0, "")
+
+	return fs
+}

--- a/app/job/schedule/schedule.go
+++ b/app/job/schedule/schedule.go
@@ -1,0 +1,70 @@
+package get
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/sfomuseum/go-offline"
+)
+
+func Run(ctx context.Context, logger *log.Logger) error {
+	fs := DefaultFlagSet()
+	return RunWithFlagSet(ctx, fs, logger)
+}
+
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+
+	flagset.Parse(fs)
+
+	offline_db, err := offline.NewDatabase(ctx, database_uri)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create offline database, %w", err)
+	}
+
+	offline_q, err := offline.NewQueue(ctx, queue_uri)
+
+	if err != nil {
+		return fmt.Errorf("Failed to create offline queue, %w", err)
+	}
+
+	job, err := offline_db.GetJob(ctx, job_id)
+
+	if err != nil {
+		return fmt.Errorf("Failed to get job, %w", err)
+	}
+
+	if job.Status != offline.Pending {
+		return fmt.Errorf("Job status is not pending (%d)", job.Status)
+	}
+
+	job.Status = offline.Queued
+
+	err = offline_db.UpdateJob(ctx, job)
+
+	if err != nil {
+		return fmt.Errorf("Failed to update offline job status (to queued), %w", err)
+	}
+
+	err = offline_q.ScheduleJob(ctx, job.Id)
+
+	if err != nil {
+
+		job.Status = offline.Pending
+
+		status_err := offline_db.UpdateJob(ctx, job)
+
+		if status_err != nil {
+			return fmt.Errorf("Failed to add offline job, %w. Also failed to update offline job status (to pending), %w", err, status_err)
+		}
+
+		return fmt.Errorf("Failed to add offline job, %w", err)
+	}
+
+	// Wait for job to complete?
+
+	return nil
+}

--- a/app/job/schedule/schedule.go
+++ b/app/job/schedule/schedule.go
@@ -1,21 +1,20 @@
-package get
+package schedule
 
 import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-offline"
 )
 
-func Run(ctx context.Context, logger *log.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *log.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	flagset.Parse(fs)
 

--- a/app/job/schedule/schedule.go
+++ b/app/job/schedule/schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 
 	"github.com/sfomuseum/go-flags/flagset"
 	"github.com/sfomuseum/go-offline"
@@ -18,22 +19,54 @@ func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	flagset.Parse(fs)
 
-	offline_db, err := offline.NewDatabase(ctx, database_uri)
+	offline_db, err := offline.NewDatabase(ctx, offline_database_uri)
 
 	if err != nil {
 		return fmt.Errorf("Failed to create offline database, %w", err)
 	}
 
-	offline_q, err := offline.NewQueue(ctx, queue_uri)
+	// START OF put me in a function with well-defined types etc.
 
-	if err != nil {
-		return fmt.Errorf("Failed to create offline queue, %w", err)
+	q_mux := make(map[string]offline.Queue)
+
+	for _, kv := range offline_queue_uris {
+
+		job_type := kv.Key()
+		offline_uri := kv.Value().(string)
+
+		_, exists := q_mux[job_type]
+
+		if exists {
+			return fmt.Errorf("Multiple values for '%s' job type", job_type)
+		}
+
+		offline_uri, err := url.QueryUnescape(offline_uri)
+
+		if err != nil {
+			return fmt.Errorf("Failed to unescape URI '%s' for job '%s', %w", offline_uri, job_type, err)
+		}
+
+		offline_q, err := offline.NewQueue(ctx, offline_uri)
+
+		if err != nil {
+			return fmt.Errorf("Failed to instantiate offline queue for '%s', %w", job_type, err)
+		}
+
+		q_mux[job_type] = offline_q
 	}
+
+	// END OF put me in a function with well-defined types etc.
 
 	job, err := offline_db.GetJob(ctx, job_id)
 
 	if err != nil {
 		return fmt.Errorf("Failed to get job, %w", err)
+	}
+
+	offline_q, ok := q_mux[job.Type]
+
+	if !ok {
+		return fmt.Errorf("Failed to derive offline queue for job type (%s)", job.Type)
 	}
 
 	if job.Status != offline.Pending {

--- a/app/server/flags.go
+++ b/app/server/flags.go
@@ -21,6 +21,7 @@ var cors_origins multi.MultiCSVString
 var cors_allow_credentials bool
 
 var path_status string
+var verbose bool
 
 func DefaultFlagSet() *flag.FlagSet {
 
@@ -39,5 +40,6 @@ func DefaultFlagSet() *flag.FlagSet {
 
 	fs.BoolVar(&cors_allow_credentials, "cors-allow-credentials", false, "A boolean flag indicating whether or not to allow credentials headers for CORS requests.")
 
+	fs.BoolVar(&verbose, "verbose", false, "Enable verbose (debug) logging.")
 	return fs
 }

--- a/app/server/options.go
+++ b/app/server/options.go
@@ -17,6 +17,7 @@ type RunOptions struct {
 	EnableCORS           bool
 	CORSAllowedOrigins   []string
 	CORSAllowCredentials bool
+	Verbose              bool
 }
 
 func DeriveRunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
@@ -70,6 +71,7 @@ func DeriveRunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
 		EnableCORS:           enable_cors,
 		CORSAllowedOrigins:   cors_origins,
 		CORSAllowCredentials: cors_allow_credentials,
+		Verbose:              verbose,
 	}
 
 	return opts, nil

--- a/app/server/options.go
+++ b/app/server/options.go
@@ -31,6 +31,8 @@ func DeriveRunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
 
 	ctx := context.Background()
 
+	// START OF put me in a function with well-defined types etc.
+
 	q_mux := make(map[string]offline.Queue)
 
 	for _, kv := range offline_queue_uris {
@@ -58,6 +60,8 @@ func DeriveRunOptionsFromFlagSet(fs *flag.FlagSet) (*RunOptions, error) {
 
 		q_mux[job_type] = offline_q
 	}
+
+	// END OF put me in a function with well-defined types etc.
 
 	opts := &RunOptions{
 		OfflineDatabaseURI:   offline_database_uri,

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aaronland/go-http-server/handler"
 )
 
-func Run(ctx context.Context, logger *slog.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *slog.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	opts, err := DeriveRunOptionsFromFlagSet(fs)
 
@@ -24,10 +24,15 @@ func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *slog.Logger) 
 		return err
 	}
 
-	return RunWithOptions(ctx, opts, logger)
+	return RunWithOptions(ctx, opts)
 }
 
-func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) error {
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
+
+	if opts.Verbose {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+		slog.Debug("Verbose logging enabled")
+	}
 
 	run_opts = opts
 
@@ -36,7 +41,8 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 		"POST /schedule": scheduleHandlerFunc,
 	}
 
-	log_logger := slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
+	slog_logger := slog.Default()
+	log_logger := slog.NewLogLogger(slog_logger.Handler(), slog.LevelInfo)
 
 	route_handler_opts := &handler.RouteHandlerOptions{
 		Handlers: handlers,

--- a/cmd/add-job/main.go
+++ b/cmd/add-job/main.go
@@ -10,11 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := add.Run(ctx, logger)
+	err := add.Run(ctx)
 
 	if err != nil {
-		logger.Fatalf("Failed to add job, %v", err)
+		log.Fatalf("Failed to add job, %v", err)
 	}
 }

--- a/cmd/get-job/main.go
+++ b/cmd/get-job/main.go
@@ -10,11 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := get.Run(ctx, logger)
+	err := get.Run(ctx)
 
 	if err != nil {
-		logger.Fatalf("Failed to add job, %v", err)
+		log.Fatalf("Failed to add job, %v", err)
 	}
 }

--- a/cmd/job-server/main.go
+++ b/cmd/job-server/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"context"
-	"log/slog"
-	"os"
+	"log"
 
 	"github.com/sfomuseum/go-offline/app/server"
 )
@@ -11,12 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := slog.Default()
-
-	err := server.Run(ctx, logger)
+	err := server.Run(ctx)
 
 	if err != nil {
-		logger.Error("Failed to add job", "error", err)
-		os.Exit(1)
+		log.Fatalf("Failed to run job server, %v", err)
 	}
 }

--- a/cmd/remove-job/main.go
+++ b/cmd/remove-job/main.go
@@ -10,11 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := log.Default()
-
-	err := remove.Run(ctx, logger)
+	err := remove.Run(ctx)
 
 	if err != nil {
-		logger.Fatalf("Failed to add job, %v", err)
+		log.Fatalf("Failed to remove job, %v", err)
 	}
 }

--- a/cmd/schedule-job/main.go
+++ b/cmd/schedule-job/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/sfomuseum/go-offline/app/job/schedule"
+)
+
+func main() {
+
+	ctx := context.Background()
+	err := schedule.Run(ctx)
+
+	if err != nil {
+		log.Fatalf("Failed to schedule job, %v", err)
+	}
+}

--- a/process.go
+++ b/process.go
@@ -23,7 +23,7 @@ func ProcessJob(ctx context.Context, opts *ProcessJobOptions) error {
 	logger = logger.With("job id", job_id)
 
 	logger.Debug("Fetch job")
-	
+
 	job, err := offline_db.GetJob(ctx, job_id)
 
 	if err != nil {


### PR DESCRIPTION
* Bug fix: Do not unmarshal and re-marshal scheduled job instructions because of int/int64 confusion
* Remove `api.ScheduleJobInput` type
* This release is NOT backwards compatible