### PR TITLE
Update `app/server` to support `-offline-queue-config-uri` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,8 @@ debug-server:
 		-offline-database-uri syncmap:// \
 		-offline-queue-uri '*=slog://' \
 		-authenticator-uri sharedsecret://s33kret
+
+debug-server-queue-config:
+	go run cmd/job-server/main.go \
+		-offline-queue-config-uri $(CONFIG_URI) \
+		-authenticator-uri sharedsecret://s33kret

--- a/app/server/flags.go
+++ b/app/server/flags.go
@@ -31,7 +31,7 @@ func DefaultFlagSet() *flag.FlagSet {
 	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "")
 	fs.Var(&offline_queue_uris, "offline-queue-uri", "One or more {JOB_TYPE}={OFFLINE_QUEUE_URI} pairs. Pairs may also be specified as a comma-separated list.")
 
-	fs.StringVar(&offline_queue_config_uri, "offline-queue-config-uri", "", "...")
+	fs.StringVar(&offline_queue_config_uri, "offline-queue-config-uri", "", "A valid gocloud.dev/runtimevar URI that will return a JSON-encoded dictionary of {JOB_TYPE}={OFFLINE_QUEUE_URI} pairs. This is a convenience flag that will assign one or more -offline-queue-uri flags at runtime.")
 
 	fs.StringVar(&authenticator_uri, "authenticator-uri", "null://", "")
 

--- a/app/server/flags.go
+++ b/app/server/flags.go
@@ -9,6 +9,7 @@ import (
 
 var offline_database_uri string
 var offline_queue_uris multi.KeyValueCSVString
+var offline_queue_config_uri string
 
 var authenticator_uri string
 
@@ -29,6 +30,8 @@ func DefaultFlagSet() *flag.FlagSet {
 
 	fs.StringVar(&offline_database_uri, "offline-database-uri", "", "")
 	fs.Var(&offline_queue_uris, "offline-queue-uri", "One or more {JOB_TYPE}={OFFLINE_QUEUE_URI} pairs. Pairs may also be specified as a comma-separated list.")
+
+	fs.StringVar(&offline_queue_config_uri, "offline-queue-config-uri", "", "...")
 
 	fs.StringVar(&authenticator_uri, "authenticator-uri", "null://", "")
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -18,7 +18,7 @@ func Run(ctx context.Context) error {
 
 func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
-	opts, err := DeriveRunOptionsFromFlagSet(fs)
+	opts, err := DeriveRunOptionsFromFlagSet(ctx, fs)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
* Update `app/server` and `cmd/server` to support `-offline-queue-config-uri` flag to allow task/queue URI configuration details to be read from a JSON dictionary. More specifically `-offline-queue-config-uri` is meant to be a `gocloud.dev/runtimevar` URI that returns a JSON-encoded dictionary of {JOB_TYPE}={OFFLINE_QUEUE_URI} pairs. This is a convenience flag that will assign one or more `-offline-queue-uri` flags at runtime.